### PR TITLE
Bug fix with too long runtimes in calib and lake char check

### DIFF
--- a/LER_template/LakeEnsemblR.yaml
+++ b/LER_template/LakeEnsemblR.yaml
@@ -93,9 +93,9 @@ calibration:                                    # calibration section
          upper: 2                               # upper bound for parameter
          initial: 1                             # initial value for parameter
          log: false                             # log transform scaling factor
-      glm_setup/min_layer_thick:
+      mixing/coef_mix_conv:
          lower: 0.1                             # lower bound for parameter
-         upper: 0.25                            # upper bound for parameter
+         upper: 0.3                            # upper bound for parameter
          initial: 0.2                           # initial value for parameter
          log: false                             # log transform scaling factor
       mixing/coef_mix_turb:

--- a/Scripts/1_Set_up_LER_folders.R
+++ b/Scripts/1_Set_up_LER_folders.R
@@ -120,7 +120,10 @@ for(i in lakes){
       start_end_dates = format(start_end_dates, "%Y-%m-%d %H:%M:%S")
       
       if(k == "calibration"){
-        start_end_dates = c(df_obs[1L, datetime], df_obs[.N, datetime])
+        # Set start and end date based on observations, unless obs exceed forcing period
+        if(as.POSIXct(df_obs[.N, datetime]) < df_meteo[.N, datetime]){
+          start_end_dates = c(df_obs[1L, datetime], df_obs[.N, datetime])
+        }
       }
       
       # Latitude and longitude: take from LakeCharacteristics file

--- a/Scripts/Checking_lake_characteristics.R
+++ b/Scripts/Checking_lake_characteristics.R
@@ -144,6 +144,35 @@ df_temp_tarawera = fread(file.path(folder_lake_char, "Tarawera", "Tarawera_temp_
 df_temp_tarawera = df_temp_tarawera[floor(log10(TIMESTAMP)) + 1 > 6L]
 fwrite(df_temp_tarawera, file.path(folder_lake_char, "Tarawera", "Tarawera_temp_daily.csv"))
 
+# Hypsograph of Taihu is upside down
+df_hyps_taihu = fread(file.path(folder_lake_char, "Taihu", "Taihu_hypsometry.csv"))
+if(df_hyps_taihu[1L, DEPTH] == 0.0 & df_hyps_taihu[1L, BATHYMETRY_AREA] == 0.0){
+  df_hyps_taihu[, BATHYMETRY_AREA := rev(BATHYMETRY_AREA)]
+}
+fwrite(df_hyps_taihu, file.path(folder_lake_char, "Taihu", "Taihu_hypsometry.csv"))
+
+# Hypsographs of Hulun and MtBold do not contain a depth 0, causing Simstrat to crash
+df_hyps_mtbold = fread(file.path(folder_lake_char, "MtBold", "MtBold_hypsometry.csv"))
+if(df_hyps_mtbold[1L, DEPTH] != 0.0 & df_hyps_mtbold[1L, DEPTH] == min(df_hyps_mtbold[, DEPTH])){
+  df_hyps_mtbold[1L, DEPTH := 0.0]
+}
+fwrite(df_hyps_mtbold, file.path(folder_lake_char, "MtBold", "MtBold_hypsometry.csv"))
+
+df_hyps_hulun = fread(file.path(folder_lake_char, "Hulun", "Hulun_hypsometry.csv"))
+if(df_hyps_hulun[1L, DEPTH] != 0.0 & df_hyps_hulun[1L, DEPTH] == min(df_hyps_hulun[, DEPTH])){
+  df_hyps_hulun[1L, DEPTH := 0.0]
+}
+fwrite(df_hyps_hulun, file.path(folder_lake_char, "Hulun", "Hulun_hypsometry.csv"))
+
+# Mozhaysk daily obs file has a depth "???" in it
+df_temp_mozhaysk = fread(file.path(folder_lake_char, "Mozhaysk", "Mozhaysk_temp_daily.csv"))
+df_temp_mozhaysk = df_temp_mozhaysk[DEPTH != "???"]
+fwrite(df_temp_mozhaysk, file.path(folder_lake_char, "Mozhaysk", "Mozhaysk_temp_daily.csv"))
+
+# Large number of digits in depth of the Delavan hypsograph causes Simstrat to crash - 4 digits will do
+df_hyps_delavan = fread(file.path(folder_lake_char, "Delavan", "Delavan_hypsometry.csv"))
+df_hyps_delavan[, DEPTH := round(DEPTH, digits = 4L)]
+fwrite(df_hyps_delavan, file.path(folder_lake_char, "Delavan", "Delavan_hypsometry.csv"))
 
 ##### Write file -----
 fwrite(df_char, file.path(folder_lake_char, "LakeCharacteristics.csv"))


### PR DESCRIPTION
Also change a parameter to calibrate for GLM: `coef_mix_conv` instead of `min_layer_thick`, which proved to be unreliable as it could cause crashes if the number of layers exceed `max_layers`. The calculation of `max_layers` has simultaneously been improved in LER, but that is only in `export_config`, so it will not be repeated during calibration. 

Several bug fixes in the obs_temp and hypsograph data, found by Johannes and myself. 