### PR TITLE
Initial profile with a maximum number of depths

### DIFF
--- a/Scripts/1_Set_up_LER_folders.R
+++ b/Scripts/1_Set_up_LER_folders.R
@@ -170,14 +170,17 @@ for(i in lakes){
       }
       
       ##### Initial temperature profile -----
-      df_init = create_init_profile2(df_obs, start_date = start_end_dates[1])
+      df_init = create_init_profile2(df_obs, start_date = start_end_dates[1],
+                                     max_depths = max_depths_init_prof)
       if(nrow(df_init) == 0L){
         df_init = create_init_profile2(df_obs, start_date = start_end_dates[1],
-                                       margin_time = months(3))
+                                       margin_time = months(3),
+                                       max_depths = max_depths_init_prof)
       }
       if(nrow(df_init) == 0L){
         df_init = create_init_profile2(df_obs, start_date = start_end_dates[1],
-                                       margin_time = months(5))
+                                       margin_time = months(5),
+                                       max_depths = max_depths_init_prof)
       }
       df_init = df_init[Depth_meter <= max_depth]
       

--- a/Scripts/1_Set_up_LER_folders.R
+++ b/Scripts/1_Set_up_LER_folders.R
@@ -208,15 +208,15 @@ for(i in lakes){
   setTxtProgressBar(progressBar,progress)
 }
 
-## fix problem with GLM fore some lakes caused by to low max_layers value
-for (i in c("Argyle", "FallingCreek", "Hassel", "Kinneret",
-            "Rimov", "Sammamish", "Tahoe", "Vendyurskoe")) {
-  glm_nml <- glmtools::read_nml(file.path(folder_root, folder_data, i,
-                                          calib_gcm, "calibration", "GLM",
-                                          "glm3.nml"))
-  glm_nml <- glmtools::set_nml(glm_nml, arg_name = 'max_layers', arg_val = 10000)
-  glmtools::write_nml(glm_nml, file = file.path(folder_root, folder_data, i,
-                                                calib_gcm, "calibration", "GLM",
-                                                "glm3.nml"))
-  
-}
+# ## fix problem with GLM fore some lakes caused by to low max_layers value
+# for (i in c("Argyle", "FallingCreek", "Hassel", "Kinneret",
+#             "Rimov", "Sammamish", "Tahoe", "Vendyurskoe")) {
+#   glm_nml <- glmtools::read_nml(file.path(folder_root, folder_data, i,
+#                                           calib_gcm, "calibration", "GLM",
+#                                           "glm3.nml"))
+#   glm_nml <- glmtools::set_nml(glm_nml, arg_name = 'max_layers', arg_val = 10000)
+#   glmtools::write_nml(glm_nml, file = file.path(folder_root, folder_data, i,
+#                                                 calib_gcm, "calibration", "GLM",
+#                                                 "glm3.nml"))
+#   
+# }

--- a/Scripts/Create_folder_structure.R
+++ b/Scripts/Create_folder_structure.R
@@ -17,6 +17,10 @@ name_couples = df_char[`Lake Short Name` %in% lakes, .(`Lake Short Name`, `Lake 
 for(i in lakes){
   lake_report = name_couples[`Lake Short Name` == i, `Lake Name Folder`]
   
+  if(lake_report == "rappbodep"){
+    lake_report = "rappbode"
+  }
+  
   for(j in gcms){
     for(k in scens){
       if(k == "calibration") next

--- a/Scripts/Settings.R
+++ b/Scripts/Settings.R
@@ -25,6 +25,9 @@ models_to_run = c("FLake", "GLM", "GOTM", "Simstrat")
 # Spin-up period used for all simulations, including the calibration
 spin_up_period = 0L
 
+# Maximum number of depths to include in the initial temperature profile
+max_depths_init_prof = 20L
+
 ##### Report settings -----
 
 report_name = "Test"
@@ -33,7 +36,7 @@ report_name = "Test"
 ##### Calibration settings -----
 
 frac_of_cores = 1.0 # Fraction of available cores to use, rounded up. 
-cal_iterations = 2000
+cal_iterations = 10 # 1000
 cmethod = "LHC" # Calibration method to use, see ?cali_ensemble
 
 #### IMPORTANT!!!!!

--- a/Scripts/create_init_profile2.R
+++ b/Scripts/create_init_profile2.R
@@ -8,15 +8,8 @@
 
 # We take 2001 as "standard" to calculate DOY, as it's not a leap year
 
-# Update 2021-09-01: changed input from a directory to a df_obs
-#                    df_obs is assumed to be a data.table, and is created in 1_Set_up_LER_folders
-
-
-# folder = "C:/Users/mesman/Documents/Projects/2021/ISIMIP3 - LakeEnsemblR/ISIMIP data/Annie"
-# start_date = "2006-01-01 00:00:00"
-# margin_time = months(1)
-
-create_init_profile2 = function(df_obs, start_date = "2001-01-01", margin_time = months(1)){
+create_init_profile2 = function(df_obs, start_date = "2001-01-01", margin_time = months(1),
+                                max_depths = 20L, round_dec = 2L){
   
   if(margin_time > months(6)){
     stop("margin_time cannot be larger than six months!")
@@ -38,8 +31,28 @@ create_init_profile2 = function(df_obs, start_date = "2001-01-01", margin_time =
     df_obs = df_obs[yday(datetime) >= minDOY | yday(datetime) <= maxDOY]
   }
   
+  # Limit the number of depths in the initial profile
+  if(length(unique(df_obs$Depth_meter)) > max_depths){
+    the_unique_depths = unique(df_obs$Depth_meter)
+    the_unique_depths = the_unique_depths[order(the_unique_depths)]
+    
+    new_depths = seq(min(the_unique_depths), max(the_unique_depths), length.out = max_depths)
+    
+    # Code partially from https://stackoverflow.com/questions/12861061/round-to-nearest-arbitrary-number-from-list
+    # Round the_unique_depths to new_depths
+    low = findInterval(df_obs$Depth_meter, new_depths)
+    high = low + 1
+    low_diff = df_obs$Depth_meter - new_depths[ifelse(low == 0, NA, low)]
+    high_diff = new_depths[ifelse(high == 0, NA, high)] - df_obs$Depth_meter
+    mins = pmin(low_diff, high_diff, na.rm = T) 
+    pick = ifelse(!is.na(low_diff) & mins == low_diff, low, high)
+    df_obs[, Depth_meter := round(new_depths[pick], round_dec)]
+    df_obs = df_obs[complete.cases(df_obs)]
+  }
+  
   # Create average profile and put in LER format
-  df_av_prof = df_obs[, mean(Water_Temperature_celsius, na.rm = T), by = Depth_meter]
+  df_av_prof = df_obs[, round(mean(Water_Temperature_celsius, na.rm = T), round_dec),
+                      by = Depth_meter]
   setnames(df_av_prof, old = "V1", new = "Water_Temperature_celsius")
   setorder(df_av_prof, Depth_meter)
   


### PR DESCRIPTION
Old method of initial profile calculations could cause initial profiles with many unique depths, which could cause GLM to crash. New code prevents this. 